### PR TITLE
Custom MongoDB JsonFormatter to write timestamp

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.csproj
+++ b/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.csproj
@@ -75,6 +75,7 @@
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Sinks\MongoDB\MongoDBJsonFormatter.cs" />
     <Compile Include="Sinks\MongoDB\MongoDBSink.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using MongoDB.Bson;
+using Serilog.Formatting.Json;
+using System;
+using System.IO;
+
+namespace Serilog.Sinks.MongoDB
+{
+    /// <summary>
+    /// JsonFormatter for MongoDB
+    /// </summary>
+    public class MongoDBJsonFormatter : JsonFormatter
+    {
+        private readonly IDictionary<Type, Action<object, TextWriter>> _dateTimeWriters;
+
+        /// <summary>
+        /// See <see cref="T:Serilog.Formatting.Json.JsonFormatter"/>.
+        /// Default JsonFormatter writes DateTimeOffset as string with round trip date/time pattern to MongoDB,
+        /// which contains the local time zone component. String search on these field, with different timezones,
+        /// will not return the correct values. This JsonFormatter writes them as MongoDB Date objects.
+        /// </summary>
+        /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
+        /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
+        /// JSON object.</param>
+        /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
+        /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
+        /// is true.</param>
+        /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
+        /// property named RenderedMessage.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        public MongoDBJsonFormatter(
+            bool omitEnclosingObject = false,
+            string closingDelimiter = null,
+            bool renderMessage = false,
+            IFormatProvider formatProvider = null)
+            : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider)
+        {
+            _dateTimeWriters = new Dictionary<Type, Action<object, TextWriter>>
+            {
+                {typeof (DateTime), (v, w) => WriteDateTime((DateTime) v, w)},
+                {typeof (DateTimeOffset), (v, w) => WriteOffset((DateTimeOffset) v, w)}
+            };
+        }
+
+        /// <summary>
+        /// Writes out a json property with the specified value on output writer
+        /// </summary>
+        protected override void WriteJsonProperty(
+            string name,
+            object value,
+            ref string precedingDelimiter,
+            TextWriter output)
+        {
+            Action<object, TextWriter> action;
+            if (value != null && _dateTimeWriters.TryGetValue(value.GetType(), out action))
+            {
+                output.Write(precedingDelimiter);
+                output.Write("\"");
+                output.Write(name);
+                output.Write("\":");
+                action(value, output);
+                precedingDelimiter = ",";
+            }
+            else
+            {
+                base.WriteJsonProperty(name, value, ref precedingDelimiter, output);
+            }
+        }
+
+        private static void WriteOffset(DateTimeOffset value, TextWriter output)
+        {
+            output.Write("{{ \"$date\" : {0} }}", BsonUtils.ToMillisecondsSinceEpoch(value.UtcDateTime));
+        }
+
+        private static void WriteDateTime(DateTime value, TextWriter output)
+        {
+            output.Write("{{ \"$date\" : {0} }}", BsonUtils.ToMillisecondsSinceEpoch(value));
+        }
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
@@ -15,7 +15,6 @@
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Serilog.Events;
-using Serilog.Formatting.Json;
 using Serilog.Sinks.PeriodicBatching;
 using System;
 using System.Collections.Generic;
@@ -124,8 +123,7 @@ namespace Serilog.Sinks.MongoDB
             var payload = new StringWriter();
             payload.Write("{\"d\":[");
 
-            var formatter = new JsonFormatter(
-                omitEnclosingObject: true,
+            var formatter = new MongoDBJsonFormatter(true,
                 renderMessage: true,
                 formatProvider: _formatProvider);
 


### PR DESCRIPTION
Create MongoDBJsonFormatter to save DateTime and DateTimeOffset as MongoDB Date objects.

Default JsonFormatter writes DateTime and DateTimeOffset field as string with round trip date/time pattern to MongoDB, which contains the local time zone component if field's object kind is local. String search on these field, with different timezones, will not return the correct values.