### PR TITLE
Add optional ctor parameter in MongoDBSink

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
@@ -21,7 +21,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 
 using Serilog.Events;
-using Serilog.Formatting.Json;
+using Serilog.Formatting;
 
 namespace Serilog.Helpers
 {
@@ -73,7 +73,7 @@ namespace Serilog.Helpers
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">
         /// </exception>
-        internal static IReadOnlyCollection<BsonDocument> GenerateBsonDocuments(this IEnumerable<LogEvent> events, JsonFormatter formatter)
+        internal static IReadOnlyCollection<BsonDocument> GenerateBsonDocuments(this IEnumerable<LogEvent> events, ITextFormatter formatter)
         {
             if (events == null) throw new ArgumentNullException(nameof(events));
 

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -17,6 +17,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.MongoDB;
 using MongoDB.Driver;
+using Serilog.Formatting;
 
 namespace Serilog
 {
@@ -35,6 +36,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MongoDB(
@@ -44,14 +46,15 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            ITextFormatter mongoDBJsonFormatter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (string.IsNullOrWhiteSpace(databaseUrl)) throw new ArgumentNullException(nameof(databaseUrl));
 
             return
                 loggerConfiguration.Sink(
-                    new MongoDBSink(databaseUrl, batchPostingLimit, period, formatProvider, collectionName),
+                    new MongoDBSink(databaseUrl, batchPostingLimit, period, formatProvider, collectionName, null, mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
         }
 
@@ -65,6 +68,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MongoDB(
@@ -74,14 +78,15 @@ namespace Serilog
             string collectionName = MongoDBSink.DefaultCollectionName,
             int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            ITextFormatter mongoDBJsonFormatter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (database == null) throw new ArgumentNullException(nameof(database));
 
             return
                 loggerConfiguration.Sink(
-                    new MongoDBSink(database, batchPostingLimit, period, formatProvider, collectionName),
+                    new MongoDBSink(database, batchPostingLimit, period, formatProvider, collectionName, null, mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
         }
 
@@ -97,6 +102,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MongoDBCapped(
@@ -108,7 +114,8 @@ namespace Serilog
             string collectionName = MongoDBSink.DefaultCollectionName,
             int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            ITextFormatter mongoDBJsonFormatter = null)
         {
 
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -129,7 +136,8 @@ namespace Serilog
                     period,
                     formatProvider,
                     collectionName,
-                    options),
+                    options,
+                    mongoDBJsonFormatter),
                 restrictedToMinimumLevel);
         }
 
@@ -145,6 +153,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MongoDBCapped(
@@ -156,7 +165,8 @@ namespace Serilog
             string collectionName = MongoDBSink.DefaultCollectionName,
             int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            IFormatProvider formatProvider = null)
+            IFormatProvider formatProvider = null,
+            ITextFormatter mongoDBJsonFormatter = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
             if (database == null) throw new ArgumentNullException(nameof(database));
@@ -176,7 +186,8 @@ namespace Serilog
                     period,
                     formatProvider,
                     collectionName,
-                    options),
+                    options,
+                    mongoDBJsonFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
@@ -24,6 +24,8 @@ using Serilog.Events;
 using Serilog.Helpers;
 using Serilog.Sinks.PeriodicBatching;
 
+using Serilog.Formatting;
+
 namespace Serilog.Sinks.MongoDB
 {
     /// <summary>
@@ -33,7 +35,7 @@ namespace Serilog.Sinks.MongoDB
     {
         readonly string _collectionName;
         readonly IMongoDatabase _mongoDatabase;
-        readonly MongoDBJsonFormatter _mongoDbJsonFormatter;
+        readonly ITextFormatter _mongoDbJsonFormatter;
 
         /// <summary>
         /// Construct a sink posting to the specified database.
@@ -44,6 +46,7 @@ namespace Serilog.Sinks.MongoDB
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
         /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         public MongoDBSink(
             string databaseUrlOrConnStrName,
             int batchPostingLimit = DefaultBatchPostingLimit,
@@ -51,7 +54,7 @@ namespace Serilog.Sinks.MongoDB
             IFormatProvider formatProvider = null,
             string collectionName = DefaultCollectionName,
             CreateCollectionOptions collectionCreationOptions = null,
-            MongoDBJsonFormatter mongoDBJsonFormatter = null)
+            ITextFormatter mongoDBJsonFormatter = null)
             : this(DatabaseFromMongoUrl(databaseUrlOrConnStrName), batchPostingLimit, period, formatProvider, collectionName, collectionCreationOptions, mongoDBJsonFormatter)
         {
         }
@@ -65,6 +68,7 @@ namespace Serilog.Sinks.MongoDB
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
         /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         public MongoDBSink(
             IMongoDatabase database,
             int batchPostingLimit = DefaultBatchPostingLimit,
@@ -72,7 +76,7 @@ namespace Serilog.Sinks.MongoDB
             IFormatProvider formatProvider = null,
             string collectionName = DefaultCollectionName,
             CreateCollectionOptions collectionCreationOptions = null,
-            MongoDBJsonFormatter mongoDBJsonFormatter = null)
+            ITextFormatter mongoDBJsonFormatter = null)
             : base(batchPostingLimit, period ?? DefaultPeriod)
         {
             if (database == null) throw new ArgumentNullException(nameof(database));

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
@@ -50,8 +50,9 @@ namespace Serilog.Sinks.MongoDB
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string collectionName = DefaultCollectionName,
-            CreateCollectionOptions collectionCreationOptions = null)
-            : this(DatabaseFromMongoUrl(databaseUrlOrConnStrName), batchPostingLimit, period, formatProvider, collectionName, collectionCreationOptions)
+            CreateCollectionOptions collectionCreationOptions = null,
+            MongoDBJsonFormatter mongoDBJsonFormatter = null)
+            : this(DatabaseFromMongoUrl(databaseUrlOrConnStrName), batchPostingLimit, period, formatProvider, collectionName, collectionCreationOptions, mongoDBJsonFormatter)
         {
         }
 
@@ -70,14 +71,15 @@ namespace Serilog.Sinks.MongoDB
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string collectionName = DefaultCollectionName,
-            CreateCollectionOptions collectionCreationOptions = null)
+            CreateCollectionOptions collectionCreationOptions = null,
+            MongoDBJsonFormatter mongoDBJsonFormatter = null)
             : base(batchPostingLimit, period ?? DefaultPeriod)
         {
             if (database == null) throw new ArgumentNullException(nameof(database));
 
             this._mongoDatabase = database;
             this._collectionName = collectionName;
-            this._mongoDbJsonFormatter = new MongoDBJsonFormatter(true, renderMessage: true, formatProvider: formatProvider);
+            this._mongoDbJsonFormatter = mongoDBJsonFormatter ?? new MongoDBJsonFormatter(true, renderMessage: true, formatProvider: formatProvider);
 
             this._mongoDatabase.VerifyCollectionExists(this._collectionName, collectionCreationOptions);
         }


### PR DESCRIPTION
MongoDBJsonFormatter can optionally be specified by the caller. One use case may be to set renderMessage = false in order to limit the payload of the document saved to MongoDB