### PR TITLE
Replacing reserved characters in the key field of the Bson document.

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
@@ -65,6 +65,7 @@ namespace Serilog.Sinks.MongoDB
             ref string precedingDelimiter,
             TextWriter output)
         {
+            name = name.Replace('$', '_').Replace('.', '-');
             Action<object, TextWriter> action;
             if (value != null && _dateTimeWriters.TryGetValue(value.GetType(), out action))
             {


### PR DESCRIPTION
We have been dealing with the issue documented [here](https://github.com/serilog/serilog-sinks-mongodb/issues/29)

This has been tested to work in our dotnet core application.