### PR TITLE
Fixed invalid key characters preventing saving of logs

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
@@ -93,7 +93,19 @@ namespace Serilog.Helpers
 
             payload.Write("]}");
 
-            var bson = BsonDocument.Parse(payload.ToString());
+            var payloadString = payload.ToString();
+            var matches = Regex.Matches(payloadString, "\\\"[\\.$][^\"]*\\\":|\\\"[^\"]*[\\.$]\\\":|\\\"[^\"]*[\\.$][^\"]*\\\":");
+
+            if (matches?.Any() ?? false)
+            {
+                var matchedValues = matches.Select(x => x.Value).Distinct().ToArray();
+                foreach (var match in matchedValues)
+                {
+                    payloadString = payloadString.Replace(match, match.Replace('.', '-').Replace('$', '_'));
+                }
+            }
+
+            var bson = BsonDocument.Parse(payloadString);
 
             return bson["logEvents"].AsBsonArray.Select(x => x.AsBsonDocument).ToList();
         }


### PR DESCRIPTION
I came across a bug in which the bson documents were not being saved to the database. Upon further testing I found out that while saving, the dictionary keys are not checked for invalid characters (`.` and `$`). 

This fix aims to resolve this problem by passing the final string through a regex pattern meant to locate precisely these two characters in field names, and replace them with safe characters.

I faced this issue when I attached the current HttpContext to the log properties. The default cookie names (`.AspNet.Consent`, `.AspNetCore.Session`, `.ga`) were causing the issue since I was saving them as a dictionary.

PS: This fix is also attached to a closed (yet not fully fixed issue) found [here](https://github.com/serilog/serilog-sinks-mongodb/issues/29#issuecomment-488742239). 