### PR TITLE
Fixing capped collection not getting created (Fixed CollectionExists always returning true)

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
@@ -35,8 +35,9 @@ namespace Serilog.Helpers
         /// <returns></returns>
         internal static bool CollectionExists(this IMongoDatabase database, string collectionName)
         {
-            var collection = database.GetCollection<BsonDocument>(collectionName);
-            return collection != null;
+            var filter = new BsonDocument("name", collectionName);
+            var collectionCursor = database.ListCollections(new ListCollectionsOptions { Filter = filter });
+            return collectionCursor.Any();
         }
 
         /// <summary>


### PR DESCRIPTION
-Fix for issue 44. 
-Reason: In CollectionExists method ,database.GetCollection() will always return a collection(a new one is created if collection doesn't exist). So we cannot use GetCollection to check if collection exists. 
-Updated CollectionExists () method logic to check if actually a collection exists by the name