### PR TITLE
Logs using Native Bson Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ var log = new LoggerConfiguration()
     .WriteTo.MongoDB("mongodb://mymongodb/logs")
     .CreateLogger();
 
+// basic usage defaults to writing to `log` collection
+var log = new LoggerConfiguration()
+    .WriteTo.MongoDB("mongodb://mymongodb/logs")
+    .CreateLogger();
+
 // creates custom collection `applog`
 var log = new LoggerConfiguration()
     .WriteTo.MongoDB("mongodb://mymongodb/logs", collectionName: "applog")
@@ -34,5 +39,27 @@ var log = new LoggerConfiguration()
 // optional parameters cappedMaxSizeMb and cappedMaxDocuments specified
 var log = new LoggerConfiguration()
     .WriteTo.MongoDBCapped("mongodb://mymongodb/logs", cappedMaxSizeMb: 50, cappedMaxDocuments: 1000)
+    .CreateLogger();
+```
+
+New in v5.0, directly seralize log events using MongoDb native Bson:
+
+```csharp
+// use Bson structured logs
+var log = new LoggerConfiguration()
+    .WriteTo.MongoDBBson("mongodb://mymongodb/logs")
+    .CreateLogger();
+
+// capped collection using Bson structured logs
+var log = new LoggerConfiguration()
+    .WriteTo.MongoDBBson("mongodb://mymongodb/logs", cfg =>
+    {
+        // optional configuration options:
+        cfg.SetCollectionName("log");
+        cfg.SetBatchPeriod(TimeSpan.FromSeconds(1));
+
+        // create capped collection that is max 100mb
+        cfg.SetCreateCappedCollection(100mb);
+    })
     .CreateLogger();
 ```

--- a/serilog-sinks-mongodb.sln.DotSettings
+++ b/serilog-sinks-mongodb.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MongoDB/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mongo/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>

--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbDocumentHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbDocumentHelpers.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+
+using MongoDB.Bson;
+
+using Serilog.Events;
+
+namespace Serilog.Helpers
+{
+    internal static class MongoDbDocumentHelpers
+    {
+        /// <summary>
+        ///     Credit to @IvaskevychYuriy for this excellent solution:
+        ///     https://github.com/serilog/serilog-sinks-mongodb/pull/59#issuecomment-830079904
+        /// </summary>
+        /// <param name="document"></param>
+        /// <returns></returns>
+        internal static BsonDocument SanitizeDocumentRecursive(this BsonDocument document)
+        {
+            var sanitizedElements = document.Select(
+                e => new BsonElement(
+                    SanitizedElementName(e.Name),
+                    e.Value.IsBsonDocument
+                        ? SanitizeDocumentRecursive(e.Value.AsBsonDocument)
+                        : e.Value));
+
+            return new BsonDocument(sanitizedElements);
+        }
+
+        internal static string SanitizedElementName(this string name)
+        {
+            if (name == null) return "[NULL]";
+
+            return name.Replace('.', '-').Replace('$', '_');
+        }
+
+        internal static BsonValue ToBsonValue(this LogEventPropertyValue value)
+        {
+            if (value == null) return null;
+
+            if (value is ScalarValue scalar) return BsonValue.Create(scalar.Value);
+
+            if (value is StructureValue sv)
+                return BsonDocument.Create(
+                    sv.Properties.ToDictionary(
+                        s => SanitizedElementName(s.Name),
+                        s => ToBsonValue(s.Value)));
+
+            if (value is DictionaryValue dv)
+                return BsonDocument.Create(
+                    dv.Elements.ToDictionary(
+                        s => SanitizedElementName(s.Key.Value?.ToString()),
+                        s => ToBsonValue(s.Value)));
+
+            if (value is SequenceValue sq)
+                return BsonValue.Create(sq.Elements.Select(ToBsonValue).ToArray());
+
+            return null;
+        }
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbDocumentHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbDocumentHelpers.cs
@@ -1,4 +1,18 @@
-﻿using System.Linq;
+﻿// Copyright 2014-2020 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
 
 using MongoDB.Bson;
 

--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
@@ -13,22 +13,18 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
 
-using Serilog.Events;
-using Serilog.Formatting;
+using Serilog.Sinks.MongoDB;
 
 namespace Serilog.Helpers
 {
     internal static class MongoDbHelper
     {
         /// <summary>
-        /// Returns true if a collection exists on the mongodb server.
+        ///     Returns true if a collection exists on the mongodb server.
         /// </summary>
         /// <param name="database">The database.</param>
         /// <param name="collectionName">Name of the collection.</param>
@@ -36,17 +32,21 @@ namespace Serilog.Helpers
         internal static bool CollectionExists(this IMongoDatabase database, string collectionName)
         {
             var filter = new BsonDocument("name", collectionName);
-            var collectionCursor = database.ListCollections(new ListCollectionsOptions { Filter = filter });
+            var collectionCursor =
+                database.ListCollections(new ListCollectionsOptions { Filter = filter });
             return collectionCursor.Any();
         }
 
         /// <summary>
-        /// Verifies the collection exists. If it doesn't, create it using the Collection Creation Options provided.
+        ///     Verifies the collection exists. If it doesn't, create it using the Collection Creation Options provided.
         /// </summary>
         /// <param name="database">The database.</param>
         /// <param name="collectionName">Name of the collection.</param>
         /// <param name="collectionCreationOptions">The collection creation options.</param>
-        internal static void VerifyCollectionExists(this IMongoDatabase database, string collectionName, CreateCollectionOptions collectionCreationOptions = null)
+        internal static void VerifyCollectionExists(
+            this IMongoDatabase database,
+            string collectionName,
+            CreateCollectionOptions collectionCreationOptions = null)
         {
             if (database == null) throw new ArgumentNullException(nameof(database));
 
@@ -64,39 +64,40 @@ namespace Serilog.Helpers
             }
         }
 
-        /// <summary>
-        /// Generate BSON documents from LogEvents.
-        /// </summary>
-        /// <param name="events">The events.</param>
-        /// <param name="formatter">The formatter.</param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException">
-        /// </exception>
-        internal static IReadOnlyCollection<BsonDocument> GenerateBsonDocuments(this IEnumerable<LogEvent> events, ITextFormatter formatter)
+        
+        internal static IMongoDatabase GetMongoDatabase(this MongoDBSinkConfiguration configuration)
         {
-            if (events == null) throw new ArgumentNullException(nameof(events));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
-            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
-
-            var payload = new StringWriter();
-
-            payload.Write(@"{""logEvents"":[");
-
-            var delimStart = "{";
-
-            foreach (var logEvent in events)
+            if (configuration.MongoDatabase != null)
             {
-                payload.Write(delimStart);
-                formatter.Format(logEvent, payload);
-                payload.Write(@",""UtcTimestamp"":""{0:u}""}}", logEvent.Timestamp.ToUniversalTime().DateTime);
-                delimStart = ",{";
+                return configuration.MongoDatabase;
             }
 
-            payload.Write("]}");
+            MongoUrl mongoUrl;
 
-            var bson = BsonDocument.Parse(payload.ToString());
+#if NET452
+            try
+            {
+                mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
+            }
+            catch (MongoConfigurationException)
+            {
+                var connectionString =
+                    ConfigurationManager.ConnectionStrings[databaseUrlOrConnStrName];
+                if (connectionString == null)
+                    throw new KeyNotFoundException(
+                        $"Invalid database url or connection string key: {databaseUrlOrConnStrName}");
 
-            return bson["logEvents"].AsBsonArray.Select(x => x.AsBsonDocument).ToList();
+                mongoUrl = MongoUrl.Create(connectionString.ConnectionString);
+            }
+#else
+            mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
+#endif
+
+            var mongoClient = new MongoClient(mongoUrl);
+
+            return mongoClient.GetDatabase(mongoUrl.DatabaseName);
         }
     }
 }

--- a/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/MongoDbHelpers.cs
@@ -63,41 +63,5 @@ namespace Serilog.Helpers
                 if (!e.ErrorMessage.Equals("collection already exists")) throw;
             }
         }
-
-        
-        internal static IMongoDatabase GetMongoDatabase(this MongoDBSinkConfiguration configuration)
-        {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-
-            if (configuration.MongoDatabase != null)
-            {
-                return configuration.MongoDatabase;
-            }
-
-            MongoUrl mongoUrl;
-
-#if NET452
-            try
-            {
-                mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
-            }
-            catch (MongoConfigurationException)
-            {
-                var connectionString =
-                    ConfigurationManager.ConnectionStrings[databaseUrlOrConnStrName];
-                if (connectionString == null)
-                    throw new KeyNotFoundException(
-                        $"Invalid database url or connection string key: {databaseUrlOrConnStrName}");
-
-                mongoUrl = MongoUrl.Create(connectionString.ConnectionString);
-            }
-#else
-            mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
-#endif
-
-            var mongoClient = new MongoClient(mongoUrl);
-
-            return mongoClient.GetDatabase(mongoUrl.DatabaseName);
-        }
     }
 }

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -29,13 +29,13 @@ namespace Serilog
     public static class LoggerConfigurationMongoDBExtensions
     {
         /// <summary>
-        ///     Adds a sink that writes log events as documents to a MongoDb database.
+        ///     Adds a sink that writes log events as bson documents to a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration"></param>
         /// <param name="configureAction"></param>
         /// <param name="restrictedToMinimumLevel"></param>
         /// <returns></returns>
-        public static LoggerConfiguration MongoDB(
+        public static LoggerConfiguration MongoDbBson(
             this LoggerSinkConfiguration loggerConfiguration,
             string mongoUrl,
             Action<MongoDBSinkConfiguration> configureAction,
@@ -59,13 +59,13 @@ namespace Serilog
         }
 
         /// <summary>
-        ///     Adds a sink that writes log events as documents to a MongoDb database.
+        ///     Adds a sink that writes log events as bson documents to a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration"></param>
         /// <param name="configureAction"></param>
         /// <param name="restrictedToMinimumLevel"></param>
         /// <returns></returns>
-        public static LoggerConfiguration MongoDB(
+        public static LoggerConfiguration MongoDbBson(
             this LoggerSinkConfiguration loggerConfiguration,
             Action<MongoDBSinkConfiguration> configureAction,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
@@ -98,7 +98,7 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDBLegacy(
+        public static LoggerConfiguration MongoDB(
             this LoggerSinkConfiguration loggerConfiguration,
             string databaseUrl,
             string collectionName = MongoDBSinkDefaults.CollectionName,
@@ -142,7 +142,7 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDBLegacy(
+        public static LoggerConfiguration MongoDB(
             this LoggerSinkConfiguration loggerConfiguration,
             IMongoDatabase database,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -190,7 +190,7 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDBCappedLegacy(
+        public static LoggerConfiguration MongoDBCapped(
             this LoggerSinkConfiguration loggerConfiguration,
             string databaseUrl,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -239,7 +239,7 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDBCappedLegacy(
+        public static LoggerConfiguration MongoDBCapped(
             this LoggerSinkConfiguration loggerConfiguration,
             IMongoDatabase database,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -35,10 +35,10 @@ namespace Serilog
         /// <param name="configureAction"></param>
         /// <param name="restrictedToMinimumLevel"></param>
         /// <returns></returns>
-        public static LoggerConfiguration MongoDbBson(
+        public static LoggerConfiguration MongoDBBson(
             this LoggerSinkConfiguration loggerConfiguration,
             string mongoUrl,
-            Action<MongoDBSinkConfiguration> configureAction,
+            Action<MongoDBSinkConfiguration> configureAction = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
             if (loggerConfiguration == null)
@@ -65,7 +65,7 @@ namespace Serilog
         /// <param name="configureAction"></param>
         /// <param name="restrictedToMinimumLevel"></param>
         /// <returns></returns>
-        public static LoggerConfiguration MongoDbBson(
+        public static LoggerConfiguration MongoDBBson(
             this LoggerSinkConfiguration loggerConfiguration,
             Action<MongoDBSinkConfiguration> configureAction,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -43,18 +43,17 @@ namespace Serilog
         {
             if (loggerConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerConfiguration));
-            if (configureAction == null) throw new ArgumentNullException(nameof(configureAction));
 
-            var configuration = new MongoDBSinkConfiguration();
+            var cfg = new MongoDBSinkConfiguration();
 
-            configuration.SetMongoUrl(mongoUrl);
+            cfg.SetMongoUrl(mongoUrl);
 
-            configureAction(configuration);
+            configureAction?.Invoke(cfg);
 
-            configuration.Validate();
+            cfg.Validate();
 
             return loggerConfiguration.Sink(
-                new MongoDBSink(configuration),
+                new MongoDBSink(cfg),
                 restrictedToMinimumLevel);
         }
 
@@ -74,14 +73,14 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(loggerConfiguration));
             if (configureAction == null) throw new ArgumentNullException(nameof(configureAction));
 
-            var configuration = new MongoDBSinkConfiguration();
+            var cfg = new MongoDBSinkConfiguration();
 
-            configureAction(configuration);
+            configureAction(cfg);
 
-            configuration.Validate();
+            cfg.Validate();
 
             return loggerConfiguration.Sink(
-                new MongoDBSink(configuration),
+                new MongoDBSink(cfg),
                 restrictedToMinimumLevel);
         }
 
@@ -113,17 +112,17 @@ namespace Serilog
             if (string.IsNullOrWhiteSpace(databaseUrl))
                 throw new ArgumentNullException(nameof(databaseUrl));
 
-            var c = new MongoDBSinkConfiguration();
+            var cfg = new MongoDBSinkConfiguration();
 
-            c.SetConnectionString(databaseUrl);
-            c.SetBatchPostingLimit(batchPostingLimit);
-            if (period.HasValue) c.SetBatchPeriod(period.Value);
-            c.SetCollectionName(collectionName);
+            cfg.SetConnectionString(databaseUrl);
+            cfg.SetBatchPostingLimit(batchPostingLimit);
+            if (period.HasValue) cfg.SetBatchPeriod(period.Value);
+            cfg.SetCollectionName(collectionName);
 
             return
                 loggerConfiguration.Sink(
                     new MongoDBSinkLegacy(
-                        c,
+                        cfg,
                         formatProvider,
                         mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
@@ -156,17 +155,17 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(loggerConfiguration));
             if (database == null) throw new ArgumentNullException(nameof(database));
 
-            var c = new MongoDBSinkConfiguration();
+            var cfg = new MongoDBSinkConfiguration();
 
-            c.SetMongoDatabase(database);
-            c.SetBatchPostingLimit(batchPostingLimit);
-            if (period.HasValue) c.SetBatchPeriod(period.Value);
-            c.SetCollectionName(collectionName);
+            cfg.SetMongoDatabase(database);
+            cfg.SetBatchPostingLimit(batchPostingLimit);
+            if (period.HasValue) cfg.SetBatchPeriod(period.Value);
+            cfg.SetCollectionName(collectionName);
 
             return
                 loggerConfiguration.Sink(
                     new MongoDBSinkLegacy(
-                        c,
+                        cfg,
                         formatProvider,
                         mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
@@ -207,18 +206,18 @@ namespace Serilog
             if (string.IsNullOrWhiteSpace(databaseUrl))
                 throw new ArgumentNullException(nameof(databaseUrl));
 
-            var c = new MongoDBSinkConfiguration();
+            var cfg = new MongoDBSinkConfiguration();
 
-            c.SetConnectionString(databaseUrl);
-            c.SetBatchPostingLimit(batchPostingLimit);
-            if (period.HasValue) c.SetBatchPeriod(period.Value);
-            c.SetCollectionName(collectionName);
-            c.SetCreateCappedCollection(cappedMaxSizeMb, cappedMaxDocuments);
+            cfg.SetConnectionString(databaseUrl);
+            cfg.SetBatchPostingLimit(batchPostingLimit);
+            if (period.HasValue) cfg.SetBatchPeriod(period.Value);
+            cfg.SetCollectionName(collectionName);
+            cfg.SetCreateCappedCollection(cappedMaxSizeMb, cappedMaxDocuments);
 
             return
                 loggerConfiguration.Sink(
                     new MongoDBSinkLegacy(
-                        c,
+                        cfg,
                         formatProvider,
                         mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
@@ -255,18 +254,18 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(loggerConfiguration));
             if (database == null) throw new ArgumentNullException(nameof(database));
 
-            var c = new MongoDBSinkConfiguration();
+            var cfg = new MongoDBSinkConfiguration();
 
-            c.SetMongoDatabase(database);
-            c.SetBatchPostingLimit(batchPostingLimit);
-            if (period.HasValue) c.SetBatchPeriod(period.Value);
-            c.SetCollectionName(collectionName);
-            c.SetCreateCappedCollection(cappedMaxSizeMb, cappedMaxDocuments);
+            cfg.SetMongoDatabase(database);
+            cfg.SetBatchPostingLimit(batchPostingLimit);
+            if (period.HasValue) cfg.SetBatchPeriod(period.Value);
+            cfg.SetCollectionName(collectionName);
+            cfg.SetCreateCappedCollection(cappedMaxSizeMb, cappedMaxDocuments);
 
             return
                 loggerConfiguration.Sink(
                     new MongoDBSinkLegacy(
-                        c,
+                        cfg,
                         formatProvider,
                         mongoDBJsonFormatter),
                     restrictedToMinimumLevel);

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -31,39 +31,10 @@ namespace Serilog
     {
         /// <summary>
         ///     Adds a sink that writes log events as bson documents to a MongoDb database.
-        /// </summary>
-        /// <param name="loggerConfiguration"></param>
-        /// <param name="configureAction"></param>
-        /// <param name="restrictedToMinimumLevel"></param>
-        /// <returns></returns>
-        public static LoggerConfiguration MongoDBBson(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string mongoUrl,
-            Action<MongoDBSinkConfiguration> configureAction = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
-        {
-            if (loggerConfiguration == null)
-                throw new ArgumentNullException(nameof(loggerConfiguration));
-
-            var cfg = new MongoDBSinkConfiguration();
-
-            cfg.SetMongoUrl(mongoUrl);
-
-            configureAction?.Invoke(cfg);
-
-            cfg.Validate();
-
-            return loggerConfiguration.Sink(
-                new MongoDBSink(cfg),
-                restrictedToMinimumLevel);
-        }
-
-        /// <summary>
-        ///     Adds a sink that writes log events as bson documents to a MongoDb database.
         ///     For AppSettings Configuration.
         /// </summary>
         /// <param name="loggerConfiguration"></param>
-        /// <param name="mongoUrl"></param>
+        /// <param name="databaseUrl">Mongo Url Connection String</param>
         /// <param name="collectionName"></param>
         /// <param name="restrictedToMinimumLevel"></param>
         /// <param name="batchPostingLimit"></param>
@@ -73,7 +44,7 @@ namespace Serilog
         /// <returns></returns>
         public static LoggerConfiguration MongoDBBson(
             this LoggerSinkConfiguration loggerConfiguration,
-            string mongoUrl,
+            string databaseUrl,
             string collectionName = MongoDBSinkDefaults.CollectionName,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
@@ -83,7 +54,7 @@ namespace Serilog
         {
             var cfg = new MongoDBSinkConfiguration();
 
-            cfg.SetMongoUrl(mongoUrl);
+            cfg.SetMongoUrl(databaseUrl);
             cfg.SetCollectionName(collectionName);
             cfg.SetBatchPostingLimit(batchPostingLimit);
 
@@ -108,6 +79,7 @@ namespace Serilog
 
         /// <summary>
         ///     Adds a sink that writes log events as bson documents to a MongoDb database.
+        ///     Fluent configuration.
         /// </summary>
         /// <param name="loggerConfiguration"></param>
         /// <param name="configureAction"></param>

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -21,6 +21,7 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.MongoDB;
 
+// ReSharper disable once CheckNamespace
 namespace Serilog
 {
     /// <summary>
@@ -49,6 +50,54 @@ namespace Serilog
             cfg.SetMongoUrl(mongoUrl);
 
             configureAction?.Invoke(cfg);
+
+            cfg.Validate();
+
+            return loggerConfiguration.Sink(
+                new MongoDBSink(cfg),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        ///     Adds a sink that writes log events as bson documents to a MongoDb database.
+        ///     For AppSettings Configuration.
+        /// </summary>
+        /// <param name="loggerConfiguration"></param>
+        /// <param name="mongoUrl"></param>
+        /// <param name="collectionName"></param>
+        /// <param name="restrictedToMinimumLevel"></param>
+        /// <param name="batchPostingLimit"></param>
+        /// <param name="period"></param>
+        /// <param name="cappedMaxSizeMb"></param>
+        /// <param name="cappedMaxDocuments"></param>
+        /// <returns></returns>
+        public static LoggerConfiguration MongoDBBson(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string mongoUrl,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
+            TimeSpan? period = null,
+            long? cappedMaxSizeMb = null,
+            long? cappedMaxDocuments = null)
+        {
+            var cfg = new MongoDBSinkConfiguration();
+
+            cfg.SetMongoUrl(mongoUrl);
+            cfg.SetCollectionName(collectionName);
+            cfg.SetBatchPostingLimit(batchPostingLimit);
+
+            if (period.HasValue)
+            {
+                cfg.SetBatchPeriod(period.Value);
+            }
+
+            if (cappedMaxSizeMb.HasValue || cappedMaxDocuments.HasValue)
+            {
+                cfg.SetCreateCappedCollection(
+                    cappedMaxSizeMb ?? MongoDBSinkDefaults.CappedCollectionMaxSizeMb,
+                    cappedMaxDocuments);
+            }
 
             cfg.Validate();
 

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -37,6 +37,36 @@ namespace Serilog
         /// <returns></returns>
         public static LoggerConfiguration MongoDB(
             this LoggerSinkConfiguration loggerConfiguration,
+            string mongoUrl,
+            Action<MongoDBSinkConfiguration> configureAction,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (configureAction == null) throw new ArgumentNullException(nameof(configureAction));
+
+            var configuration = new MongoDBSinkConfiguration();
+
+            configuration.SetMongoUrl(mongoUrl);
+
+            configureAction(configuration);
+
+            configuration.Validate();
+
+            return loggerConfiguration.Sink(
+                new MongoDBSink(configuration),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        ///     Adds a sink that writes log events as documents to a MongoDb database.
+        /// </summary>
+        /// <param name="loggerConfiguration"></param>
+        /// <param name="configureAction"></param>
+        /// <param name="restrictedToMinimumLevel"></param>
+        /// <returns></returns>
+        public static LoggerConfiguration MongoDB(
+            this LoggerSinkConfiguration loggerConfiguration,
             Action<MongoDBSinkConfiguration> configureAction,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
@@ -47,6 +77,8 @@ namespace Serilog
             var configuration = new MongoDBSinkConfiguration();
 
             configureAction(configuration);
+
+            configuration.Validate();
 
             return loggerConfiguration.Sink(
                 new MongoDBSink(configuration),
@@ -78,7 +110,6 @@ namespace Serilog
         {
             if (loggerConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerConfiguration));
-
             if (string.IsNullOrWhiteSpace(databaseUrl))
                 throw new ArgumentNullException(nameof(databaseUrl));
 

--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -13,21 +13,32 @@
 // limitations under the License.
 
 using System;
+
+using MongoDB.Driver;
+
 using Serilog.Configuration;
 using Serilog.Events;
-using Serilog.Sinks.MongoDB;
-using MongoDB.Driver;
 using Serilog.Formatting;
+using Serilog.Sinks.MongoDB;
 
 namespace Serilog
 {
     /// <summary>
-    /// Adds the WriteTo.MongoDB() extension method to <see cref="LoggerConfiguration"/>.
+    ///     Adds the WriteTo.MongoDB() extension method to <see cref="LoggerConfiguration" />.
     /// </summary>
     public static class LoggerConfigurationMongoDBExtensions
     {
+        public static LoggerConfiguration MongoDB(
+            this LoggerSinkConfiguration loggerConfiguration,
+            Action<MongoDBSinkConfiguration> configureAction,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+
+        }
+
+
         /// <summary>
-        /// Adds a sink that writes log events as documents to a MongoDb database.
+        ///     Adds a sink that writes log events as documents to a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="databaseUrl">The URL of a created MongoDB collection that log events will be written to.</param>
@@ -39,27 +50,36 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDB(
+        public static LoggerConfiguration MongoDBLegacy(
             this LoggerSinkConfiguration loggerConfiguration,
             string databaseUrl,
-            string collectionName = MongoDBSink.DefaultCollectionName,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             ITextFormatter mongoDBJsonFormatter = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-            if (string.IsNullOrWhiteSpace(databaseUrl)) throw new ArgumentNullException(nameof(databaseUrl));
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (string.IsNullOrWhiteSpace(databaseUrl))
+                throw new ArgumentNullException(nameof(databaseUrl));
 
             return
                 loggerConfiguration.Sink(
-                    new MongoDBSink(databaseUrl, batchPostingLimit, period, formatProvider, collectionName, null, mongoDBJsonFormatter),
+                    new MongoDBSinkLegacy(
+                        databaseUrl,
+                        batchPostingLimit,
+                        period,
+                        formatProvider,
+                        collectionName,
+                        null,
+                        mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
         }
 
         /// <summary>
-        /// Adds a sink that writes log events as documents to a MongoDb database.
+        ///     Adds a sink that writes log events as documents to a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="database">The MongoDb database where the log collection will live.</param>
@@ -71,30 +91,41 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDB(
+        public static LoggerConfiguration MongoDBLegacy(
             this LoggerSinkConfiguration loggerConfiguration,
             IMongoDatabase database,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string collectionName = MongoDBSink.DefaultCollectionName,
-            int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             ITextFormatter mongoDBJsonFormatter = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
             if (database == null) throw new ArgumentNullException(nameof(database));
 
             return
                 loggerConfiguration.Sink(
-                    new MongoDBSink(database, batchPostingLimit, period, formatProvider, collectionName, null, mongoDBJsonFormatter),
+                    new MongoDBSinkLegacy(
+                        database,
+                        batchPostingLimit,
+                        period,
+                        formatProvider,
+                        collectionName,
+                        null,
+                        mongoDBJsonFormatter),
                     restrictedToMinimumLevel);
         }
 
         /// <summary>
-        /// Adds a sink that writes log events as documents to a capped collection in a MongoDb database.
+        ///     Adds a sink that writes log events as documents to a capped collection in a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="databaseUrl">The URL of a MongoDb database where the log collection will live (used for backwards compatibility).</param>
+        /// <param name="databaseUrl">
+        ///     The URL of a MongoDb database where the log collection will live (used for backwards
+        ///     compatibility).
+        /// </param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="cappedMaxSizeMb">Max total size in megabytes of the created capped collection. (Default: 50mb)</param>
         /// <param name="cappedMaxDocuments">Max number of documents of the created capped collection.</param>
@@ -105,32 +136,33 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDBCapped(
+        public static LoggerConfiguration MongoDBCappedLegacy(
             this LoggerSinkConfiguration loggerConfiguration,
             string databaseUrl,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             long cappedMaxSizeMb = 50,
             long? cappedMaxDocuments = null,
-            string collectionName = MongoDBSink.DefaultCollectionName,
-            int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             ITextFormatter mongoDBJsonFormatter = null)
         {
-
-            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
-            if (string.IsNullOrWhiteSpace(databaseUrl)) throw new ArgumentNullException(nameof(databaseUrl));
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (string.IsNullOrWhiteSpace(databaseUrl))
+                throw new ArgumentNullException(nameof(databaseUrl));
 
             var options = new CreateCollectionOptions
-            {
-                Capped = true,
-                MaxSize = cappedMaxSizeMb * 1024 * 1024
-            };
+                          {
+                              Capped = true,
+                              MaxSize = cappedMaxSizeMb * 1024 * 1024
+                          };
 
             if (cappedMaxDocuments.HasValue) options.MaxDocuments = cappedMaxDocuments.Value;
 
             return loggerConfiguration.Sink(
-                new MongoDBSink(
+                new MongoDBSinkLegacy(
                     databaseUrl,
                     batchPostingLimit,
                     period,
@@ -142,7 +174,7 @@ namespace Serilog
         }
 
         /// <summary>
-        /// Adds a sink that writes log events as documents to a capped collection in a MongoDb database.
+        ///     Adds a sink that writes log events as documents to a capped collection in a MongoDb database.
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="database">The MongoDb database where the log collection will live.</param>
@@ -156,31 +188,32 @@ namespace Serilog
         /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MongoDBCapped(
+        public static LoggerConfiguration MongoDBCappedLegacy(
             this LoggerSinkConfiguration loggerConfiguration,
             IMongoDatabase database,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             long cappedMaxSizeMb = 50,
             long? cappedMaxDocuments = null,
-            string collectionName = MongoDBSink.DefaultCollectionName,
-            int batchPostingLimit = MongoDBSink.DefaultBatchPostingLimit,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             ITextFormatter mongoDBJsonFormatter = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException(nameof(loggerConfiguration));
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
             if (database == null) throw new ArgumentNullException(nameof(database));
 
-            var options = new CreateCollectionOptions()
-            {
-                Capped = true,
-                MaxSize = cappedMaxSizeMb * 1024 * 1024
-            };
+            var options = new CreateCollectionOptions
+                          {
+                              Capped = true,
+                              MaxSize = cappedMaxSizeMb * 1024 * 1024
+                          };
 
             if (cappedMaxDocuments.HasValue) options.MaxDocuments = cappedMaxDocuments.Value;
 
             return loggerConfiguration.Sink(
-                new MongoDBSink(
+                new MongoDBSinkLegacy(
                     database,
                     batchPostingLimit,
                     period,

--- a/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.csproj
+++ b/src/Serilog.Sinks.MongoDB/Serilog.Sinks.MongoDB.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net4.5;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard15</TargetFrameworks>
     <ProjectGuid>2605ed8c-c12a-42fb-9825-32ffea7b4301</ProjectGuid>
     <RootNamespace>Serilog.Sinks.MongoDB</RootNamespace>
   </PropertyGroup>
@@ -19,12 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.3.0" />
-    <PackageReference Include="Serilog" Version="2.3.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.3" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/LogEntry.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/LogEntry.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2014-2020 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+
+using MongoDB.Bson;
+
+using Serilog.Events;
+
+namespace Serilog.Sinks.MongoDB
+{
+    public class LogEntry
+    {
+        public DateTime UtcTimeStamp { get; set; }
+
+        public MessageTemplate MessageTemplate { get; set; }
+
+        public string RenderedMessage { get; set; }
+
+        public Exception Exception { get; set; }
+
+        public BsonDocument Properties { get; set; }
+
+        public static LogEntry MapFrom(LogEvent logEvent)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+
+            return new LogEntry
+                   {
+                       MessageTemplate = logEvent.MessageTemplate,
+                       RenderedMessage = logEvent.RenderMessage(),
+                       UtcTimeStamp = logEvent.Timestamp.ToUniversalTime().UtcDateTime,
+                       Exception = logEvent.Exception,
+                       Properties = BsonDocument.Create(
+                           logEvent.Properties.ToDictionary(s => s.Key, s => ToBsonValue(s.Value)))
+                   };
+        }
+
+        internal static BsonValue ToBsonValue(LogEventPropertyValue value)
+        {
+            if (value == null) return null;
+
+            if (value is ScalarValue scalar) return BsonValue.Create(scalar.Value);
+
+            if (value is StructureValue sv)
+                return BsonDocument.Create(
+                    sv.Properties.ToDictionary(s => s.Name, s => ToBsonValue(s.Value)));
+
+            if (value is DictionaryValue dv)
+                return BsonDocument.Create(
+                    dv.Elements.ToDictionary(s => s.Key.Value, s => ToBsonValue(s.Value)));
+
+            if (value is SequenceValue sq)
+                return BsonValue.Create(sq.Elements.Select(ToBsonValue).ToArray());
+
+            return null;
+        }
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/LogEntry.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/LogEntry.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using MongoDB.Bson;
 
 using Serilog.Events;
+using Serilog.Helpers;
 
 namespace Serilog.Sinks.MongoDB
 {
@@ -42,61 +43,12 @@ namespace Serilog.Sinks.MongoDB
                        MessageTemplate = logEvent.MessageTemplate,
                        RenderedMessage = logEvent.RenderMessage(),
                        UtcTimeStamp = logEvent.Timestamp.ToUniversalTime().UtcDateTime,
-                       Exception = logEvent.Exception == null ? null : SanitizeDocumentRecursive(logEvent.Exception.ToBsonDocument()),
+                       Exception = logEvent.Exception?.ToBsonDocument().SanitizeDocumentRecursive(),
                        Properties = BsonDocument.Create(
                            logEvent.Properties.ToDictionary(
-                               s => SanitizedElementName(s.Key),
-                               s => ToBsonValue(s.Value)))
+                               s => s.Key.SanitizedElementName(),
+                               s => s.Value.ToBsonValue()))
                    };
-        }
-
-        /// <summary>
-        /// Credit to @IvaskevychYuriy for this excellent solution:
-        /// https://github.com/serilog/serilog-sinks-mongodb/pull/59#issuecomment-830079904
-        /// </summary>
-        /// <param name="document"></param>
-        /// <returns></returns>
-        private static BsonDocument SanitizeDocumentRecursive(BsonDocument document)
-        {
-            var sanitizedElements = document.Select(
-                e => new BsonElement(
-                    SanitizedElementName(e.Name),
-                    e.Value.IsBsonDocument
-                        ? SanitizeDocumentRecursive(e.Value.AsBsonDocument)
-                        : e.Value));
-
-            return new BsonDocument(sanitizedElements);
-        }
-
-        private static string SanitizedElementName(string name)
-        {
-            if (name == null) return "[NULL]";
-
-            return name.Replace('.', '-').Replace('$', '_');
-        }
-
-        internal static BsonValue ToBsonValue(LogEventPropertyValue value)
-        {
-            if (value == null) return null;
-
-            if (value is ScalarValue scalar) return BsonValue.Create(scalar.Value);
-
-            if (value is StructureValue sv)
-                return BsonDocument.Create(
-                    sv.Properties.ToDictionary(
-                        s => SanitizedElementName(s.Name),
-                        s => ToBsonValue(s.Value)));
-
-            if (value is DictionaryValue dv)
-                return BsonDocument.Create(
-                    dv.Elements.ToDictionary(
-                        s => SanitizedElementName(s.Key.Value?.ToString()),
-                        s => ToBsonValue(s.Value)));
-
-            if (value is SequenceValue sq)
-                return BsonValue.Create(sq.Elements.Select(ToBsonValue).ToArray());
-
-            return null;
         }
     }
 }

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.MongoDB
     /// <summary>
     /// JsonFormatter for MongoDB
     /// </summary>
-    public class MongoDbJsonFormatter : JsonFormatter
+    public class MongoDBJsonFormatter : JsonFormatter
     {
         private readonly IDictionary<Type, Action<object, TextWriter>> _dateTimeWriters;
 
@@ -44,7 +44,7 @@ namespace Serilog.Sinks.MongoDB
         /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
         /// property named RenderedMessage.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        public MongoDbJsonFormatter(
+        public MongoDBJsonFormatter(
             bool omitEnclosingObject = false,
             string closingDelimiter = null,
             bool renderMessage = false,

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
-using MongoDB.Bson;
-using Serilog.Formatting.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
+
+using MongoDB.Bson;
+
+using Serilog.Formatting.Json;
 
 namespace Serilog.Sinks.MongoDB
 {
     /// <summary>
     /// JsonFormatter for MongoDB
     /// </summary>
-    public class MongoDBJsonFormatter : JsonFormatter
+    public class MongoDbJsonFormatter : JsonFormatter
     {
         private readonly IDictionary<Type, Action<object, TextWriter>> _dateTimeWriters;
 
@@ -42,18 +44,18 @@ namespace Serilog.Sinks.MongoDB
         /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
         /// property named RenderedMessage.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        public MongoDBJsonFormatter(
+        public MongoDbJsonFormatter(
             bool omitEnclosingObject = false,
             string closingDelimiter = null,
             bool renderMessage = false,
             IFormatProvider formatProvider = null)
             : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider)
         {
-            _dateTimeWriters = new Dictionary<Type, Action<object, TextWriter>>
-            {
-                {typeof (DateTime), (v, w) => WriteDateTime((DateTime) v, w)},
-                {typeof (DateTimeOffset), (v, w) => WriteOffset((DateTimeOffset) v, w)}
-            };
+            this._dateTimeWriters = new Dictionary<Type, Action<object, TextWriter>>
+                                    {
+                                        {typeof (DateTime), (v, w) => WriteDateTime((DateTime) v, w)},
+                                        {typeof (DateTimeOffset), (v, w) => WriteOffset((DateTimeOffset) v, w)}
+                                    };
         }
 
         /// <summary>
@@ -67,7 +69,7 @@ namespace Serilog.Sinks.MongoDB
         {
             name = name.Replace('$', '_').Replace('.', '-');
             Action<object, TextWriter> action;
-            if (value != null && _dateTimeWriters.TryGetValue(value.GetType(), out action))
+            if (value != null && this._dateTimeWriters.TryGetValue(value.GetType(), out action))
             {
                 output.Write(precedingDelimiter);
                 output.Write("\"");

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBJsonFormatter.cs
@@ -68,8 +68,8 @@ namespace Serilog.Sinks.MongoDB
             TextWriter output)
         {
             name = name.Replace('$', '_').Replace('.', '-');
-            Action<object, TextWriter> action;
-            if (value != null && this._dateTimeWriters.TryGetValue(value.GetType(), out action))
+
+            if (value != null && this._dateTimeWriters.TryGetValue(value.GetType(), out var action))
             {
                 output.Write(precedingDelimiter);
                 output.Write("\"");
@@ -79,7 +79,9 @@ namespace Serilog.Sinks.MongoDB
                 precedingDelimiter = ",";
             }
             else
+            {
                 base.WriteJsonProperty(name, value, ref precedingDelimiter, output);
+            }
         }
 
         private static void WriteOffset(DateTimeOffset value, TextWriter output)

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using MongoDB.Bson.Serialization;
-using MongoDB.Driver;
 
 using Serilog.Events;
 
@@ -22,42 +21,12 @@ namespace Serilog.Sinks.MongoDB
                         cm.MapProperty(s => s.Message);
                         cm.MapProperty(s => s.Source);
                         cm.MapProperty(s => s.StackTrace);
-                        cm.MapProperty(s => s.TargetSite);
                         cm.MapProperty(s => s.Data);
                     });
         }
 
-        public MongoDBSink(
-            string databaseUrlOrConnStrName,
-            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
-            TimeSpan? period = null,
-            IFormatProvider formatProvider = null,
-            string collectionName = MongoDBSinkDefaults.CollectionName,
-            CreateCollectionOptions collectionCreationOptions = null)
-            : base(
-                databaseUrlOrConnStrName,
-                batchPostingLimit,
-                period,
-                formatProvider,
-                collectionName,
-                collectionCreationOptions)
-        {
-        }
-
-        public MongoDBSink(
-            IMongoDatabase database,
-            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
-            TimeSpan? period = null,
-            IFormatProvider formatProvider = null,
-            string collectionName = MongoDBSinkDefaults.CollectionName,
-            CreateCollectionOptions collectionCreationOptions = null)
-            : base(
-                database,
-                batchPostingLimit,
-                period,
-                formatProvider,
-                collectionName,
-                collectionCreationOptions)
+        public MongoDBSink(MongoDBSinkConfiguration configuration)
+            : base(configuration)
         {
         }
 

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2020 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSink.cs
@@ -1,164 +1,69 @@
-﻿// Copyright 2014-2020 Serilog Contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
-using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 using Serilog.Events;
-using Serilog.Helpers;
-using Serilog.Sinks.PeriodicBatching;
-
-using Serilog.Formatting;
 
 namespace Serilog.Sinks.MongoDB
 {
-    /// <summary>
-    /// Writes log events as documents to a MongoDB database.
-    /// </summary>
-    public class MongoDBSink : PeriodicBatchingSink
+    public class MongoDBSink : MongoDBSinkBase
     {
-        readonly string _collectionName;
-        readonly IMongoDatabase _mongoDatabase;
-        readonly ITextFormatter _mongoDbJsonFormatter;
+        static MongoDBSink()
+        {
+            if (!BsonClassMap.IsClassMapRegistered(typeof(Exception)))
+                BsonClassMap.RegisterClassMap<Exception>(
+                    cm =>
+                    {
+                        cm.AutoMap();
+                        cm.MapProperty(s => s.Message);
+                        cm.MapProperty(s => s.Source);
+                        cm.MapProperty(s => s.StackTrace);
+                        cm.MapProperty(s => s.TargetSite);
+                        cm.MapProperty(s => s.Data);
+                    });
+        }
 
-        /// <summary>
-        /// Construct a sink posting to the specified database.
-        /// </summary>
-        /// <param name="databaseUrlOrConnStrName">The URL of a MongoDB database, or connection string name containing the URL.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
-        /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
-        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         public MongoDBSink(
             string databaseUrlOrConnStrName,
-            int batchPostingLimit = DefaultBatchPostingLimit,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            string collectionName = DefaultCollectionName,
-            CreateCollectionOptions collectionCreationOptions = null,
-            ITextFormatter mongoDBJsonFormatter = null)
-            : this(DatabaseFromMongoUrl(databaseUrlOrConnStrName), batchPostingLimit, period, formatProvider, collectionName, collectionCreationOptions, mongoDBJsonFormatter)
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            CreateCollectionOptions collectionCreationOptions = null)
+            : base(
+                databaseUrlOrConnStrName,
+                batchPostingLimit,
+                period,
+                formatProvider,
+                collectionName,
+                collectionCreationOptions)
         {
         }
 
-        /// <summary>
-        /// Construct a sink posting to a specified database.
-        /// </summary>
-        /// <param name="database">The MongoDB database.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
-        /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
-        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         public MongoDBSink(
             IMongoDatabase database,
-            int batchPostingLimit = DefaultBatchPostingLimit,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            string collectionName = DefaultCollectionName,
-            CreateCollectionOptions collectionCreationOptions = null,
-            ITextFormatter mongoDBJsonFormatter = null)
-            : base(batchPostingLimit, period ?? DefaultPeriod)
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            CreateCollectionOptions collectionCreationOptions = null)
+            : base(
+                database,
+                batchPostingLimit,
+                period,
+                formatProvider,
+                collectionName,
+                collectionCreationOptions)
         {
-            if (database == null) throw new ArgumentNullException(nameof(database));
-
-            this._mongoDatabase = database;
-            this._collectionName = collectionName;
-            this._mongoDbJsonFormatter = mongoDBJsonFormatter ?? new MongoDBJsonFormatter(true, renderMessage: true, formatProvider: formatProvider);
-
-            this._mongoDatabase.VerifyCollectionExists(this._collectionName, collectionCreationOptions);
         }
 
-        /// <summary>
-        /// A reasonable default for the number of events posted in
-        /// each batch.
-        /// </summary>
-        public const int DefaultBatchPostingLimit = 50;
-
-        /// <summary>
-        /// A reasonable default time to wait between checking for event batches.
-        /// </summary>
-        public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
-
-        /// <summary>
-        /// The default name for the log collection.
-        /// </summary>
-        public const string DefaultCollectionName = "log";
-
-        /// <summary>
-        /// Get the MongoDatabase for a specified database url
-        /// </summary>
-        /// <param name="databaseUrlOrConnStrName">The URL of a MongoDB database, or connection string name containing the URL.</param>
-        /// <returns>The Mongodatabase</returns>
-        static IMongoDatabase DatabaseFromMongoUrl(string databaseUrlOrConnStrName)
-        {
-            if (string.IsNullOrWhiteSpace(databaseUrlOrConnStrName))
-                throw new ArgumentNullException(nameof(databaseUrlOrConnStrName));
-
-            MongoUrl mongoUrl;
-
-#if NET_45
-            try
-            {
-                mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
-            }
-            catch (MongoConfigurationException)
-            {
-                var connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[databaseUrlOrConnStrName];
-                if (connectionString == null)
-                    throw new KeyNotFoundException($"Invalid database url or connection string key: {databaseUrlOrConnStrName}");
-
-                mongoUrl = MongoUrl.Create(connectionString.ConnectionString);
-            }
-#else
-            mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
-#endif
-
-            var mongoClient = new MongoClient(mongoUrl);
-            return mongoClient.GetDatabase(mongoUrl.DatabaseName);
-        }
-
-        /// <summary>
-        /// Gets the log collection.
-        /// </summary>
-        /// <returns></returns>
-        IMongoCollection<BsonDocument> GetLogCollection()
-        {
-            return this._mongoDatabase.GetCollection<BsonDocument>(this._collectionName);
-        }
-
-        /// <summary>
-        /// Emit a batch of log events, running asynchronously.
-        /// </summary>
-        /// <param name="events">The events to emit.</param>
-        /// <returns></returns>
-        /// <remarks>
-        /// Override either <see cref="M:Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink.EmitBatch(System.Collections.Generic.IEnumerable{Serilog.Events.LogEvent})" /> or <see cref="M:Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink.EmitBatchAsync(System.Collections.Generic.IEnumerable{Serilog.Events.LogEvent})" />,
-        /// not both. Overriding EmitBatch() is preferred.
-        /// </remarks>
         protected override Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
-            var docs = events.GenerateBsonDocuments(this._mongoDbJsonFormatter);
-            return Task.WhenAll(this.GetLogCollection().InsertManyAsync(docs));
+            return this.InsertMany(events.Select(LogEntry.MapFrom));
         }
     }
 }

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkBase.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkBase.cs
@@ -37,17 +37,13 @@ namespace Serilog.Sinks.MongoDB
         /// <summary>
         ///     Construct a sink posting to a specified database.
         /// </summary>
-        /// <param name="database">The MongoDB database.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
-        /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
-        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
         protected MongoDBSinkBase(MongoDBSinkConfiguration configuration)
             : base(configuration.BatchPostingLimit, configuration.BatchPeriod)
         {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
 
             this._configuration = configuration;
             this._mongoDatabase = TryGetMongoDatabaseFromConfiguration(configuration);
@@ -63,8 +59,8 @@ namespace Serilog.Sinks.MongoDB
                 return configuration.MongoDatabase;
             }
 
-            var mongoDatabase = new MongoClient(configuration.MongoUrl).GetDatabase(
-                configuration.MongoUrl.DatabaseName);
+            var mongoDatabase = new MongoClient(configuration.MongoUrl)
+                .GetDatabase(configuration.MongoUrl.DatabaseName);
 
             mongoDatabase.VerifyCollectionExists(
                 configuration.CollectionName,

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkBase.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkBase.cs
@@ -1,0 +1,138 @@
+﻿// Copyright 2014-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Threading.Tasks;
+
+using MongoDB.Driver;
+
+using Serilog.Helpers;
+using Serilog.Sinks.PeriodicBatching;
+
+namespace Serilog.Sinks.MongoDB
+{
+    /// <summary>
+    ///     Writes log events as documents to a MongoDb database.
+    /// </summary>
+    public abstract class MongoDBSinkBase : PeriodicBatchingSink
+    {
+        private readonly string _collectionName;
+
+        private readonly IMongoDatabase _mongoDatabase;
+
+        /// <summary>
+        ///     Construct a sink posting to the specified database.
+        /// </summary>
+        /// <param name="databaseUrlOrConnStrName">The URL of a MongoDB database, or connection string name containing the URL.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
+        /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
+        protected MongoDBSinkBase(
+            string databaseUrlOrConnStrName,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
+            TimeSpan? period = null,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            CreateCollectionOptions collectionCreationOptions = null)
+            : this(
+                DatabaseFromMongoUrl(databaseUrlOrConnStrName),
+                batchPostingLimit,
+                period,
+                collectionName,
+                collectionCreationOptions)
+        {
+        }
+
+        /// <summary>
+        ///     Construct a sink posting to a specified database.
+        /// </summary>
+        /// <param name="database">The MongoDB database.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="collectionName">Name of the MongoDb collection to use for the log. Default is "log".</param>
+        /// <param name="collectionCreationOptions">Collection Creation Options for the log collection creation.</param>
+        /// <param name="mongoDBJsonFormatter">Formatter to produce json for MongoDB.</param>
+        protected MongoDBSinkBase(
+            IMongoDatabase database,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
+            TimeSpan? period = null,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            CreateCollectionOptions collectionCreationOptions = null)
+            : base(batchPostingLimit, period ?? MongoDBSinkDefaults.BatchPeriod)
+        {
+            if (database == null) throw new ArgumentNullException(nameof(database));
+
+            this._mongoDatabase = database;
+            this._collectionName = collectionName;
+            this._mongoDatabase.VerifyCollectionExists(
+                this._collectionName,
+                collectionCreationOptions);
+        }
+
+        /// <summary>
+        ///     Get the MongoDatabase for a specified database url
+        /// </summary>
+        /// <param name="databaseUrlOrConnStrName">The URL of a MongoDB database, or connection string name containing the URL.</param>
+        /// <returns>The Mongodatabase</returns>
+        private static IMongoDatabase DatabaseFromMongoUrl(string databaseUrlOrConnStrName)
+        {
+            if (string.IsNullOrWhiteSpace(databaseUrlOrConnStrName))
+                throw new ArgumentNullException(nameof(databaseUrlOrConnStrName));
+
+            MongoUrl mongoUrl;
+
+#if NET452
+            try
+            {
+                mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
+            }
+            catch (MongoConfigurationException)
+            {
+                var connectionString =
+                    ConfigurationManager.ConnectionStrings[databaseUrlOrConnStrName];
+                if (connectionString == null)
+                    throw new KeyNotFoundException(
+                        $"Invalid database url or connection string key: {databaseUrlOrConnStrName}");
+
+                mongoUrl = MongoUrl.Create(connectionString.ConnectionString);
+            }
+#else
+            mongoUrl = MongoUrl.Create(databaseUrlOrConnStrName);
+#endif
+
+            var mongoClient = new MongoClient(mongoUrl);
+
+            return mongoClient.GetDatabase(mongoUrl.DatabaseName);
+        }
+
+        /// <summary>
+        ///     Gets the log collection.
+        /// </summary>
+        /// <returns></returns>
+        protected IMongoCollection<T> GetCollection<T>()
+        {
+            return this._mongoDatabase.GetCollection<T>(this._collectionName);
+        }
+
+        protected Task InsertMany<T>(IEnumerable<T> objects)
+        {
+            return Task.WhenAll(this.GetCollection<T>().InsertManyAsync(objects));
+        }
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Configuration;
+
+using MongoDB.Driver;
+
+namespace Serilog.Sinks.MongoDB
+{
+    public class MongoDBSinkConfiguration
+    {
+        public string CollectionName { get; private set; } = MongoDBSinkDefaults.CollectionName;
+
+        public int BatchPostingLimit { get; private set; } = MongoDBSinkDefaults.BatchPostingLimit;
+
+        public CreateCollectionOptions CollectionCreationOptions { get; private set; }
+
+        public TimeSpan BatchPeriod { get; private set; } = MongoDBSinkDefaults.BatchPeriod;
+
+        public MongoUrl MongoUrl { get; private set; }
+
+        public IMongoDatabase MongoDatabase { get; private set; }
+
+        /// <summary>
+        ///     Set the periodic batch timeout period. (Default: 2 seconds)
+        /// </summary>
+        /// <param name="period"></param>
+        public void SetBatchPeriod(TimeSpan period)
+        {
+            this.BatchPeriod = period;
+        }
+
+        /// <summary>
+        ///     Setup capped collections during collection creation
+        /// </summary>
+        /// <param name="cappedMaxSizeMb"></param>
+        /// <param name="cappedMaxDocuments"></param>
+        public void SetCreateCappedCollection(
+            long cappedMaxSizeMb = 50,
+            long? cappedMaxDocuments = null)
+        {
+            this.CollectionCreationOptions = new CreateCollectionOptions
+                                             {
+                                                 Capped = true,
+                                                 MaxSize = cappedMaxSizeMb * 1024 * 1024
+                                             };
+
+            if (cappedMaxDocuments.HasValue)
+                this.CollectionCreationOptions.MaxDocuments = cappedMaxDocuments.Value;
+        }
+
+        /// <summary>
+        ///     Set the mongo database instance directly
+        /// </summary>
+        /// <param name="database"></param>
+        public void SetMongoDatabase(IMongoDatabase database)
+        {
+            this.MongoDatabase = database ?? throw new ArgumentNullException(nameof(database));
+            this.MongoUrl = null;
+        }
+
+        /// <summary>
+        ///     Set the mongo url (connection string) -- e.g. mongodb://localhost
+        /// </summary>
+        /// <param name="mongoUrl"></param>
+        public void SetMongoUrl(string mongoUrl)
+        {
+            if (string.IsNullOrWhiteSpace(mongoUrl))
+                throw new ArgumentNullException(nameof(mongoUrl));
+
+            this.MongoUrl = MongoUrl.Create(mongoUrl);
+            this.MongoDatabase = null;
+        }
+
+        /// <summary>
+        ///     Set the MongoDB collection name (Default: 'logs')
+        /// </summary>
+        /// <param name="collectionName"></param>
+        public void SetCollectionName(string collectionName)
+        {
+            this.CollectionName = collectionName ?? MongoDBSinkDefaults.CollectionName;
+        }
+
+        /// <summary>
+        ///     Set the batch posting limit (Default: 50)
+        /// </summary>
+        /// <param name="batchPostingLimit"></param>
+        public void SetBatchPostingLimit(int batchPostingLimit)
+        {
+            this.BatchPostingLimit = batchPostingLimit;
+        }
+
+#if NET452
+        /// <summary>
+        ///     Tries to set the Mongo url from a connection string in the .config file.
+        /// </summary>
+        /// <returns>false if not found</returns>
+        /// <param name="connectionStringName"></param>
+        public bool TrySetMongoUrlFromConnectionStringNamed(string connectionStringName)
+        {
+            if (string.IsNullOrWhiteSpace(connectionStringName))
+                throw new ArgumentNullException(nameof(connectionStringName));
+
+            var connectionString =
+                ConfigurationManager.ConnectionStrings[connectionStringName];
+
+            if (connectionString == null)
+                return false;
+
+            this.SetMongoUrl(connectionString.ConnectionString);
+
+            return true;
+        }
+
+        /// <summary>
+        ///     Set the Mongo url (connection string) or Connection String Name -- e.g. mongodb://localhost
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void SetConnectionString(string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentNullException(nameof(connectionString));
+
+            if (!this.TrySetMongoUrlFromConnectionStringNamed(connectionString))
+                this.SetMongoUrl(connectionString);
+        }
+#endif
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2020 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 using MongoDB.Driver;
 

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
@@ -22,7 +22,7 @@ namespace Serilog.Sinks.MongoDB
         {
             if (MongoDatabase == null && MongoUrl == null)
             {
-                throw new ArgumentOutOfRangeException("Invalid Configuration: MongoDatabase or Mongo Connection String must be set");
+                throw new ArgumentOutOfRangeException("Invalid Configuration: MongoDatabase or Mongo Connection String must be specified.");
             }
         }
 

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
@@ -22,7 +22,16 @@ namespace Serilog.Sinks.MongoDB
         {
             if (MongoDatabase == null && MongoUrl == null)
             {
-                throw new ArgumentOutOfRangeException("Invalid Configuration: MongoDatabase or Mongo Connection String must be specified.");
+                throw new ArgumentOutOfRangeException(
+                    "MongoDatabase or MongoUrl",
+                    "Invalid Configuration: MongoDatabase or Mongo Connection String must be specified.");
+            }
+
+            if (MongoUrl != null && string.IsNullOrWhiteSpace(MongoUrl.DatabaseName))
+            {
+                throw new ArgumentNullException(
+                    nameof(MongoUrl.DatabaseName),
+                    "Database name is required in the MongoDb connection string. Use: mongodb://mongoDbServer/databaseName");
             }
         }
 
@@ -38,8 +47,8 @@ namespace Serilog.Sinks.MongoDB
         /// <summary>
         ///     Setup capped collections during collection creation
         /// </summary>
-        /// <param name="cappedMaxSizeMb"></param>
-        /// <param name="cappedMaxDocuments"></param>
+        /// <param name="cappedMaxSizeMb">(Optional) Max Size in Mb of the Capped Collection. Default is 50mb.</param>
+        /// <param name="cappedMaxDocuments">(Optional) Max Number of Documents in the Capped Collection. Default is none.</param>
         public void SetCreateCappedCollection(
             long cappedMaxSizeMb = 50,
             long? cappedMaxDocuments = null)
@@ -65,7 +74,7 @@ namespace Serilog.Sinks.MongoDB
         }
 
         /// <summary>
-        ///     Set the mongo url (connection string) -- e.g. mongodb://localhost
+        ///     Set the mongo url (connection string) -- e.g. mongodb://localhost/databaseName
         /// </summary>
         /// <param name="mongoUrl"></param>
         public void SetMongoUrl(string mongoUrl)

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
@@ -64,7 +64,7 @@ namespace Serilog.Sinks.MongoDB
         /// <param name="cappedMaxSizeMb">(Optional) Max Size in Mb of the Capped Collection. Default is 50mb.</param>
         /// <param name="cappedMaxDocuments">(Optional) Max Number of Documents in the Capped Collection. Default is none.</param>
         public void SetCreateCappedCollection(
-            long cappedMaxSizeMb = 50,
+            long cappedMaxSizeMb = MongoDBSinkDefaults.CappedCollectionMaxSizeMb,
             long? cappedMaxDocuments = null)
         {
             this.CollectionCreationOptions = new CreateCollectionOptions

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 
 using MongoDB.Driver;
 
@@ -18,6 +17,14 @@ namespace Serilog.Sinks.MongoDB
         public MongoUrl MongoUrl { get; private set; }
 
         public IMongoDatabase MongoDatabase { get; private set; }
+
+        public void Validate()
+        {
+            if (MongoDatabase == null && MongoUrl == null)
+            {
+                throw new ArgumentOutOfRangeException("Invalid Configuration: MongoDatabase or Mongo Connection String must be set");
+            }
+        }
 
         /// <summary>
         ///     Set the periodic batch timeout period. (Default: 2 seconds)
@@ -76,6 +83,11 @@ namespace Serilog.Sinks.MongoDB
         /// <param name="collectionName"></param>
         public void SetCollectionName(string collectionName)
         {
+            if (collectionName == string.Empty)
+            {
+                throw new ArgumentOutOfRangeException(nameof(collectionName), "Must not be string.empty");
+            }
+
             this.CollectionName = collectionName ?? MongoDBSinkDefaults.CollectionName;
         }
 
@@ -100,7 +112,7 @@ namespace Serilog.Sinks.MongoDB
                 throw new ArgumentNullException(nameof(connectionStringName));
 
             var connectionString =
-                ConfigurationManager.ConnectionStrings[connectionStringName];
+                System.Configuration.ConfigurationManager.ConnectionStrings[connectionStringName];
 
             if (connectionString == null)
                 return false;
@@ -121,6 +133,18 @@ namespace Serilog.Sinks.MongoDB
 
             if (!this.TrySetMongoUrlFromConnectionStringNamed(connectionString))
                 this.SetMongoUrl(connectionString);
+        }
+#else
+        /// <summary>
+        ///     Set the Mongo url (connection string)
+        /// </summary>
+        /// <param name="connectionString"></param>
+        public void SetConnectionString(string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentNullException(nameof(connectionString));
+
+            this.SetMongoUrl(connectionString);
         }
 #endif
     }

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkDefaults.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkDefaults.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Serilog.Sinks.MongoDB
+{
+    public static class MongoDBSinkDefaults
+    {
+        /// <summary>
+        ///     A reasonable default for the number of events posted in
+        ///     each batch.
+        /// </summary>
+        public const int BatchPostingLimit = 50;
+
+        /// <summary>
+        ///     The default name for the log collection.
+        /// </summary>
+        public const string CollectionName = "log";
+
+        /// <summary>
+        ///     A reasonable default time to wait between checking for event batches.
+        /// </summary>
+        public static readonly TimeSpan BatchPeriod = TimeSpan.FromSeconds(2);
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkDefaults.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkDefaults.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2020 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Serilog.Sinks.MongoDB
 {

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkDefaults.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkDefaults.cs
@@ -30,6 +30,11 @@ namespace Serilog.Sinks.MongoDB
         public const string CollectionName = "log";
 
         /// <summary>
+        ///     Default capped collection max size in megabytes
+        /// </summary>
+        public const int CappedCollectionMaxSizeMb = 50;
+
+        /// <summary>
         ///     A reasonable default time to wait between checking for event batches.
         /// </summary>
         public static readonly TimeSpan BatchPeriod = TimeSpan.FromSeconds(2);

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
@@ -23,6 +23,7 @@ using MongoDB.Driver;
 
 using Serilog.Events;
 using Serilog.Formatting;
+using Serilog.Helpers;
 
 namespace Serilog.Sinks.MongoDB
 {
@@ -73,7 +74,8 @@ namespace Serilog.Sinks.MongoDB
 
             var bson = BsonDocument.Parse(payload.ToString());
 
-            return bson["logEvents"].AsBsonArray.Select(x => x.AsBsonDocument).ToList();
+            return bson["logEvents"].AsBsonArray
+                .Select(x => x.AsBsonDocument.SanitizeDocumentRecursive()).ToList();
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
@@ -1,0 +1,128 @@
+﻿// Copyright 2014-2020 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.MongoDB
+{
+    public class MongoDBSinkLegacy : MongoDBSinkBase
+    {
+        private readonly ITextFormatter _formatter;
+
+        public MongoDBSinkLegacy(
+            string databaseUrlOrConnStrName,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            CreateCollectionOptions collectionCreationOptions = null,
+            ITextFormatter textFormatter = null)
+            : base(
+                databaseUrlOrConnStrName,
+                batchPostingLimit,
+                period,
+                collectionName,
+                collectionCreationOptions)
+        {
+            this._formatter = textFormatter ?? new MongoDbJsonFormatter(
+                                  renderMessage: true,
+                                  formatProvider: formatProvider);
+        }
+
+        public MongoDBSinkLegacy(
+            IMongoDatabase database,
+            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null,
+            string collectionName = MongoDBSinkDefaults.CollectionName,
+            CreateCollectionOptions collectionCreationOptions = null,
+            ITextFormatter textFormatter = null)
+            : base(
+                database,
+                batchPostingLimit,
+                period,
+                collectionName,
+                collectionCreationOptions)
+        {
+            this._formatter = textFormatter ?? new MongoDbJsonFormatter(
+                                  renderMessage: true,
+                                  formatProvider: formatProvider);
+        }
+
+        /// <summary>
+        ///     Generate BSON documents from LogEvents.
+        /// </summary>
+        /// <param name="events">The events.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">
+        /// </exception>
+        protected IReadOnlyCollection<BsonDocument> GenerateBsonDocuments(
+            IEnumerable<LogEvent> events)
+        {
+            if (events == null) throw new ArgumentNullException(nameof(events));
+
+            var payload = new StringWriter();
+
+            payload.Write(@"{""logEvents"":[");
+
+            var delimStart = "{";
+
+            foreach (var logEvent in events)
+            {
+                payload.Write(delimStart);
+                this._formatter.Format(logEvent, payload);
+                payload.Write(
+                    @",""UtcTimestamp"":""{0:u}""}}",
+                    logEvent.Timestamp.ToUniversalTime().DateTime);
+                delimStart = ",{";
+            }
+
+            payload.Write("]}");
+
+            var bson = BsonDocument.Parse(payload.ToString());
+
+            return bson["logEvents"].AsBsonArray.Select(x => x.AsBsonDocument).ToList();
+        }
+
+        /// <summary>
+        ///     Emit a batch of log events, running asynchronously.
+        /// </summary>
+        /// <param name="events">The events to emit.</param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     Override either
+        ///     <see
+        ///         cref="M:Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink.EmitBatch(System.Collections.Generic.IEnumerable{Serilog.Events.LogEvent})" />
+        ///     or
+        ///     <see
+        ///         cref="M:Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink.EmitBatchAsync(System.Collections.Generic.IEnumerable{Serilog.Events.LogEvent})" />
+        ///     ,
+        ///     not both. Overriding EmitBatch() is preferred.
+        /// </remarks>
+        protected override Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        {
+            return this.InsertMany(this.GenerateBsonDocuments(events));
+        }
+    }
+}

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
@@ -36,7 +36,7 @@ namespace Serilog.Sinks.MongoDB
             ITextFormatter textFormatter = null)
             : base(configuration)
         {
-            this._formatter = textFormatter ?? new MongoDbJsonFormatter(
+            this._formatter = textFormatter ?? new MongoDBJsonFormatter(
                                   renderMessage: true,
                                   formatProvider: formatProvider);
         }

--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/MongoDBSinkLegacy.cs
@@ -31,39 +31,10 @@ namespace Serilog.Sinks.MongoDB
         private readonly ITextFormatter _formatter;
 
         public MongoDBSinkLegacy(
-            string databaseUrlOrConnStrName,
-            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
-            TimeSpan? period = null,
+            MongoDBSinkConfiguration configuration,
             IFormatProvider formatProvider = null,
-            string collectionName = MongoDBSinkDefaults.CollectionName,
-            CreateCollectionOptions collectionCreationOptions = null,
             ITextFormatter textFormatter = null)
-            : base(
-                databaseUrlOrConnStrName,
-                batchPostingLimit,
-                period,
-                collectionName,
-                collectionCreationOptions)
-        {
-            this._formatter = textFormatter ?? new MongoDbJsonFormatter(
-                                  renderMessage: true,
-                                  formatProvider: formatProvider);
-        }
-
-        public MongoDBSinkLegacy(
-            IMongoDatabase database,
-            int batchPostingLimit = MongoDBSinkDefaults.BatchPostingLimit,
-            TimeSpan? period = null,
-            IFormatProvider formatProvider = null,
-            string collectionName = MongoDBSinkDefaults.CollectionName,
-            CreateCollectionOptions collectionCreationOptions = null,
-            ITextFormatter textFormatter = null)
-            : base(
-                database,
-                batchPostingLimit,
-                period,
-                collectionName,
-                collectionCreationOptions)
+            : base(configuration)
         {
             this._formatter = textFormatter ?? new MongoDbJsonFormatter(
                                   renderMessage: true,


### PR DESCRIPTION
A lot of the problems with the sink are related to the conversion to a Json style output in MongoDB. Instead, this adds a new option (MongoDBBson()) that outputs using native Bson serialization keeping the structure of the log events.